### PR TITLE
Make entrypoint explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-file-previewer",
   "version": "0.1.0",
-  "main": "src/FilePreviewer.js",
+  "main": "src/index.js",
   "repository": "git@github.com:vendorpay/file-previewer.git",
   "author": "yolo<rec@weareyolo.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import FilePreviewer from './FilePreviewer';
+
+export default FilePreviewer;


### PR DESCRIPTION
Makes package entry point explicit by adding and `index.js`. It's way easier to know at first glance what's the main file of the library